### PR TITLE
hp-envy: provide cachix token to Nix via netrc-file

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,8 +1,26 @@
 {
   "nodes": {
+    "agenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1641576265,
+        "narHash": "sha256-G4W39k5hdu2kS13pi/RhyTOySAo7rmrs7yMUZRH0OZI=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "08b9c96878b2f9974fc8bde048273265ad632357",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
     "breeze": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "utils": "utils"
       },
       "locked": {
@@ -21,7 +39,7 @@
     },
     "brightness": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "purs-nix": "purs-nix",
         "utils": "utils_3"
       },
@@ -41,7 +59,7 @@
     },
     "flake-make": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "purs-nix": "purs-nix_2",
         "utils": "utils_5"
       },
@@ -182,7 +200,7 @@
     "json-format": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1607397660,
@@ -200,7 +218,7 @@
     },
     "localVim": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1611084859,
@@ -267,7 +285,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1609520816,
@@ -284,12 +302,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1615513511,
-        "narHash": "sha256-3Ro7OjPqmMjeV3P710TqMueGxqQNGYL7dNn/5TLhlYA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c5147860e23ed75ce9d40298c66b416c00be1167",
-        "type": "github"
+        "lastModified": 1618628710,
+        "narHash": "sha256-9xIoU+BrCpjs5nfWcd/GlU7XCVdnNKJPffoNTxgGfhs=",
+        "path": "/nix/store/z1rf17q0fxj935cmplzys4gg6nxj1as0-source",
+        "rev": "7919518f0235106d050c77837df5e338fb94de5d",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",
@@ -314,6 +331,22 @@
     },
     "nixpkgs_10": {
       "locked": {
+        "lastModified": 1611413872,
+        "narHash": "sha256-nD9e3f9P+YQ1qDSHdRXIAor40eqANBv1o03zGvpJsnM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe08be60cb84148a3dba29cfdb090fa185cacdaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.09",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
         "lastModified": 1607659006,
         "narHash": "sha256-thOt100nFeQU6LyBdrbnm2n7V4+UNnijLVGb2Ls7IE0=",
         "owner": "NixOS",
@@ -326,7 +359,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1635336330,
         "narHash": "sha256-EPrCZTmuOEY1KLjUCu7rXCBxNemggIFJMDdfEqXQKGo=",
@@ -344,6 +377,20 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1615513511,
+        "narHash": "sha256-3Ro7OjPqmMjeV3P710TqMueGxqQNGYL7dNn/5TLhlYA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5147860e23ed75ce9d40298c66b416c00be1167",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1608723372,
         "narHash": "sha256-XoCD827n1+bBPVxjKFmAikh7KSIspj9BBj2vnWhtTC4=",
         "owner": "NixOS",
@@ -356,7 +403,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1617929752,
         "narHash": "sha256-ji0nqJUZp2bfHvO0sKxD24cW6Nk7LyjbPPMxjbJHji0=",
@@ -372,7 +419,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1617984351,
         "narHash": "sha256-mo/tmR1sVmQ+4uziIAZpdNnr9AG0NAAo9Md3tucf73k=",
@@ -388,7 +435,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1607112761,
         "narHash": "sha256-JPLqSLlw7oDK2nUK/uzrjJMJFwppUbGZ19EbSLzqPA0=",
@@ -402,7 +449,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1610942247,
         "narHash": "sha256-PKo1ATAlC6BmfYSRmX0TVmNoFbrec+A5OKcabGEu2yU=",
@@ -416,7 +463,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1638535497,
         "narHash": "sha256-tk5LNbdkUhALp00+r5ZmQ3t7n2d5M7YUQB+MznWvVOg=",
@@ -432,7 +479,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1602702596,
         "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
@@ -445,22 +492,6 @@
         "id": "nixpkgs",
         "ref": "nixos-20.09-small",
         "type": "indirect"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1611413872,
-        "narHash": "sha256-nD9e3f9P+YQ1qDSHdRXIAor40eqANBv1o03zGvpJsnM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fe08be60cb84148a3dba29cfdb090fa185cacdaa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-20.09",
-        "repo": "nixpkgs",
-        "type": "github"
       }
     },
     "purs-nix": {
@@ -501,6 +532,7 @@
     },
     "root": {
       "inputs": {
+        "agenix": "agenix",
         "breeze": "breeze",
         "brightness": "brightness",
         "flake-make": "flake-make",
@@ -508,7 +540,7 @@
         "im-home": "im-home",
         "json-format": "json-format",
         "localVim": "localVim",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-neovim": "nixpkgs-neovim",
         "ssbm": "ssbm",
         "utils": "utils_6",
@@ -534,7 +566,7 @@
     "ssbm": {
       "inputs": {
         "nix": "nix",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_10",
         "slippi-desktop": "slippi-desktop"
       },
       "locked": {
@@ -554,7 +586,7 @@
     "utils": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1614319620,
@@ -642,7 +674,7 @@
     "utils_6": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1607971648,
@@ -677,7 +709,7 @@
     },
     "z": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_12",
         "utils": "utils_7"
       },
       "locked": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,6 +2,7 @@
     { breeze.url = "github:ursi/breeze";
       brightness.url = "github:ursi/brightness";
       flake-make.url = "github:ursi/flake-make";
+      agenix.url = "github:ryantm/agenix";
 
       hours =
         { flake = false;
@@ -18,7 +19,8 @@
     };
 
   outputs =
-    { breeze
+    { agenix
+    , breeze
     , brightness
     , flake-make
     , hours
@@ -111,6 +113,8 @@
                  modules =
                    [ { _module.args = { inherit nixpkgs; }; }
                      ./configuration.nix
+                     agenix.nixosModules.age
+                     { environment.systemPackages = [ agenix.defaultPackage.${system} ]; }
                      ssbm.nixosModule
                      z.nixosModule
                    ]

--- a/nix/hp-envy/default.nix
+++ b/nix/hp-envy/default.nix
@@ -3,6 +3,7 @@
   { imports =
       [ ./hardware-configuration.nix
         ../hardware/mice/simple-corsair.nix
+        ../useSecrets.nix
       ];
 
     boot =

--- a/nix/secrets/ardana-cachix-auth.age
+++ b/nix/secrets/ardana-cachix-auth.age
@@ -1,0 +1,18 @@
+age-encryption.org/v1
+-> ssh-ed25519 btHr/w 3tjfEQ4YqTVNtFGrHLa2yYINy1yplE6u+wPlf8bMkSY
+T87H0qeJiPobu2OnAoKeim4Jbh2YKWPeOt2LvxbsVbQ
+-> ssh-rsa Cj5t1w
+DCTjGwi1yvPODZMMHMkzWfnL2SRnEZWDx3gF8oADl99se5BB/R6qmIRGEc+RSLbg
+lrPCiiLZocwh4QiZXRMHxcojdQBk026eLuiqUPREJNYVW358+N9TfRvL0i31pfxL
+VPPSISlHHn73DgGz5sZKfdZR2r3iD5lIW0IipCa0YkmvFeJ6sgvlLk82yaTg79cm
+nqpCenbDr15fk6f/12PtZAhBj0YXou8EKWHItJrtPigqnG2PsHf0TsXRhipFA0Cd
+/1q6QOZxZQkeTv72Os6oTLZxt6dA8+KA1KwAFRh7u98p3sdbBrhsw1vzvq/1eMI0
+sIXLiM93axkjsYSGXPaOTxsoAzJW7vz9QZ88Z4P17yOYEkthBtVq7OImIgsz6YSA
+/gWx8cV4331y5Fs6uhtr/yD3la95rEm4WiL/p/SsmB3vegosxAZUj3HWucJdFeJ0
+WPHXPrs8HT2R3oB2bR7Fh6AGbmniwE1yN8IuB2Oh6nuDiI/3u5NAJuPQsq6yI27G
+-> ssh-ed25519 QlO7lA yoJVT5pNGCuqgRFjqKQI+OxipOQ0ZbJK/aAMW0BMOgs
+j+OVAhdlGy5iAUWJ/xcqSe2x5NcHDWu3Jn9iTUyEH9U
+-> ysyc+@Y-grease .[x0OGZ bWR
+Yc4IftBrt1m3jdcmU0sXsaIwadCiY929fw3CepB5Qrf9Ig
+--- nuHgG4SXKsxfFxakkxCU6yfK7Xkv9X42VrgjYesAQoQ
+·T˜T—Ÿ1Î‰¨OkceÇ ¢ÈX¤~2ð]ðê±_½ló	(æÖ£^]‹µ‹`Ñ9…#„_$ºæCìke!ì

--- a/nix/secrets/secrets.nix
+++ b/nix/secrets/secrets.nix
@@ -1,0 +1,12 @@
+let
+  systems = {
+    hp-envy = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOjLWvLvgY4VSV3rvihTjjLRtgHQIA50U43ALdl66IzO root@hp-envy";
+  };
+  users = {
+    matthew-t480 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQClm+SMN9Bg1HZ+MjH1VQYEXAnslGWT9564pj/KGO79WMQLUxdp3WWa1hQadf2PleAIEFEul3knrpRSEK3yHcCk3g+sCh3XIJcFZLesswe0V+kCAw+JBSd18ESJ4Qko+iDK95cDzucLFwXB10FMVKQCrX90KR+Fp6s6eJHcZGmpxTPgNulDpAjM2APluM3xBCe6zZzt+iNIzn3J8PRKbpNNbuw/LMRU8+udrGbLavUMcSk7ER9pAyLGhz//9aHWDPu7ZRje+vTWgnGFpzbtEzdjnP+2v45nLKWG7o7WdTAsAR8WSccjtNoBiVgSmpHr07zJ0/gTeL4PUkk3lbtzF/PdtTQGm3Ng4SjOBlhRVaTuKBlF2X/Rwq+W4LCbHVgA79MyhJxL2TDbKBPUSLfckqxP89e8Q7iQ4XjIHqVb50ojNNLGcOQRrHq14Twwx/ZDDQvMXCsLwM6vyoYa8KdSaASEr1clx78qNp9PHGlr+UztW+EsoZI7j1tzcHMmq2BSK90= matthew@t480";
+    ursi-hp-envy = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICiC9a/2NVbF8Viqvq3kPdzIkQwAJUbK8btC54ovtMJa masondeanm@aol.com";
+  };
+in
+{
+  "ardana-cachix-auth.age".publicKeys = [ users.ursi-hp-envy users.matthew-t480 systems.hp-envy ];
+}

--- a/nix/useSecrets.nix
+++ b/nix/useSecrets.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+{
+  age = {
+    identityPaths = [ "/etc/ssh/ssh_host_ed25519_key.pub" ];
+    secrets = {
+      ardana-cachix-auth = {
+        group = "wheel";
+        mode = "0040";
+        file = secrets/ardana-cachix-auth.age;
+      };
+    };
+  };
+  nix.extraOptions = ''
+    netrc-file = ${config.age.secrets.ardana-cachix-auth.path}
+  '';
+}


### PR DESCRIPTION
This uses [Agenix](https://github.com/ryantm/agenix) to provide a `netrc-file` to Nix for all users in the `wheel` group. That `netrc` file contains the contents of the `secrets/ardana-cachix-auth.age` file. 

Run `nix run github:ryantm/agenix -- -e ardana-cachix-auth.age` whilst inside of the `secrets` directory to edit the secret. You can do that like this:
